### PR TITLE
feat(attribute_directives): tooltip demo and popover exercise

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,7 @@ module.exports = function (grunt) {
         frameworks: ['jasmine'],
         files: [
           'lib/jquery-1.10.2.js',
+          'lib/positioning.js',
           'lib/angular.js',
           'lib/angular-mocks.js',
           'lib/jasmine-matchers.js',

--- a/lib/positioning.js
+++ b/lib/positioning.js
@@ -1,0 +1,44 @@
+function calculatePosition(hostEl, elToPosition, placement) {
+
+  var calculatedPosition;
+
+  // Get the position, height and width of both elements
+  // so we can center tooltips / popovers
+  var hostPosition = angular.extend({}, hostEl.position(), {
+    width: hostEl.prop('offsetWidth'),
+    height: hostEl.prop('offsetHeight')
+  });
+
+  var ttWidth = elToPosition.prop('offsetWidth');
+  var ttHeight = elToPosition.prop('offsetHeight');
+
+  // Calculate the tooltip's top and left coordinates to center it
+  switch (placement) {
+    case 'right':
+      calculatedPosition = {
+        top: hostPosition.top + hostPosition.height / 2 - ttHeight / 2,
+        left: hostPosition.left + hostPosition.width
+      };
+      break;
+    case 'bottom':
+      calculatedPosition = {
+        top: hostPosition.top + hostPosition.height,
+        left: hostPosition.left + hostPosition.width / 2 - ttWidth / 2
+      };
+      break;
+    case 'left':
+      calculatedPosition = {
+        top: hostPosition.top + hostPosition.height / 2 - ttHeight / 2,
+        left: hostPosition.left - ttWidth
+      };
+      break;
+    default: // top
+      calculatedPosition = {
+        top: hostPosition.top - ttHeight,
+        left: hostPosition.left + hostPosition.width / 2 - ttWidth / 2
+      };
+      break;
+  }
+
+  return calculatedPosition;
+}

--- a/src/attribute_directives/demo/README.md
+++ b/src/attribute_directives/demo/README.md
@@ -1,0 +1,16 @@
+* creating directive basics
+** declaring directives - `.directive()` factory method
+** factory method vs. compile vs. link
+** prefix directives to avoid collisions, ideally with your own project identifier (2-3 letters)
+* DOM manipulation goes into directives
+** element passed to a directive is already jQuery / jqLite - wrapped
+** registering DOM event handlers
+** direct DOM manipulation in a directive - jQury can be useful for low-level DOM routines
+* normalization of directive / attribute names
+* observing attributes vs. attribute value straight from the DOM
+* tests
+** introduction to the DOM-based directives testing
+** jQuery is useful for:
+*** matching rendered HTML
+*** triggering events
+** in order to test size / positioning we would have to attach elements to <body> but this would slow down tests

--- a/src/attribute_directives/demo/index.html
+++ b/src/attribute_directives/demo/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Integration with NgModelController - using $render()</title>
+    <link href="../../../assets/bootstrap.min.css" rel="stylesheet"/>
+    <script src="../../../lib/jquery-1.10.2.js"></script>
+    <script src="../../../lib/angular.js"></script>
+    <script src="../../../lib/positioning.js"></script>
+    <script src="tooltip.js"></script>
+
+    <script type="text/javascript">
+        angular.module('demo', ['bs.tooltip'])
+                .controller('TooltipCtrl', function ($scope) {
+                    $scope.ttipText = 'Some content';
+                    
+                });
+    </script>
+
+</head>
+<body ng-app="demo" ng-controller="TooltipCtrl">
+<div class="well" style="padding: 3%">
+    <input class="form-control" ng-model="ttipText"/>
+</div>
+<div class="well" style="padding: 3%">
+    <button class="btn btn-default" bs-tooltip="{{ttipText}}" bs-tooltip-placement="left">Left</button>
+    <button class="btn btn-default" bs-tooltip="{{ttipText}}" bs-tooltip-placement="top">Top</button>
+    <button class="btn btn-default" bs-tooltip="{{ttipText}}" bs-tooltip-placement="right">Right</button>
+    <button class="btn btn-default" bs-tooltip="{{ttipText}}" bs-tooltip-placement="bottom">Bottom</button>
+</div>
+
+</body>
+</html>

--- a/src/attribute_directives/demo/tooltip.js
+++ b/src/attribute_directives/demo/tooltip.js
@@ -1,0 +1,45 @@
+angular.module('bs.tooltip', [])
+  .directive('bsTooltip', function () {
+
+    var tooltipTpl =
+      '<div class="tooltip">' +
+        '<div class="tooltip-inner"></div>' +
+        '<div class="tooltip-arrow"></div>' +
+      '</div>';
+
+    return {
+
+      compile: function (tElement, tAttrs) {
+
+        var placement = tAttrs.bsTooltipPlacement || 'top';
+        var tooltipTplEl = angular.element(tooltipTpl);
+        tooltipTplEl.addClass(placement);
+
+        return function (scope, iElement, iAttrs) {
+
+          var tooltipInstanceEl = tooltipTplEl.clone();
+
+          //observe interpolated attributes and update tooltip's content accordingly
+          iAttrs.$observe('bsTooltip', function(newContent) {
+            tooltipInstanceEl.find('div.tooltip-inner').text(newContent);
+          });
+
+          iElement.on('mouseenter', function () {
+
+            //attach tooltip to the DOM to gets its size
+            iElement.after(tooltipInstanceEl);
+
+            //calculate position
+            var ttipPosition = calculatePosition(iElement, tooltipInstanceEl, placement);
+            tooltipInstanceEl.css(ttipPosition);
+            //finally show the tooltip
+            tooltipInstanceEl.addClass('in');
+          });
+
+          iElement.on('mouseleave', function () {
+            tooltipInstanceEl.remove();
+          });
+        };
+      }
+    };
+  });

--- a/src/attribute_directives/demo/tooltip.spec.js
+++ b/src/attribute_directives/demo/tooltip.spec.js
@@ -1,0 +1,57 @@
+describe('tooltip', function () {
+
+  var $scope, $compile;
+
+  beforeEach(module('bs.tooltip'));
+  beforeEach(inject(function ($rootScope, _$compile_) {
+    $scope = $rootScope;
+    $compile = _$compile_;
+  }));
+
+  function compileElement(elementString, scope) {
+    var element = $compile(elementString)(scope);
+    scope.$digest();
+    return element;
+  }
+
+  it('should show and hide tooltip on mouse enter / leave', function () {
+    var elm = compileElement('<div><button bs-tooltip="content"></button></div>', $scope);
+
+    elm.find('button').mouseenter();
+    expect(elm.find('.tooltip').length).toEqual(1);
+
+    elm.find('button').mouseleave();
+    expect(elm.find('.tooltip').length).toEqual(0);
+  });
+
+  it('should observe interpolated content', function () {
+    $scope.content = 'foo';
+    var elm = compileElement('<div><button bs-tooltip="{{content}}"></button></div>', $scope);
+
+    elm.find('button').mouseenter();
+    expect(elm.find('.tooltip-inner').text()).toEqual('foo');
+
+    $scope.content = 'bar';
+    $scope.$digest();
+    expect(elm.find('.tooltip-inner').text()).toEqual('bar');
+  });
+
+  describe('placement', function () {
+
+    it('should be placed on top by default', function () {
+      var elm = compileElement('<div><button bs-tooltip="content"></button></div>', $scope);
+
+      elm.find('button').mouseenter();
+      expect(elm.find('.tooltip')).toHaveClass('top');
+    });
+
+    it('should accept placement attribute', function () {
+      var elm = compileElement('<div><button bs-tooltip="content" bs-tooltip-placement="right"></button></div>', $scope);
+
+      elm.find('button').mouseenter();
+      expect(elm.find('.tooltip')).toHaveClass('right');
+      expect(elm.find('.tooltip')).not.toHaveClass('top');
+    });
+
+  });
+});

--- a/src/attribute_directives/exercise/index.html
+++ b/src/attribute_directives/exercise/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Integration with NgModelController - using $render()</title>
+    <link href="../../../assets/bootstrap.min.css" rel="stylesheet"/>
+    <script src="../../../lib/jquery-1.10.2.js"></script>
+    <script src="../../../lib/angular.js"></script>
+    <script src="../../../lib/positioning.js"></script>
+    <script src="popover.js"></script>
+
+    <script type="text/javascript">
+        angular.module('demo', ['bs.popover'])
+                .controller('PopoverCtrl', function ($scope) {
+                    $scope.title = 'A title';
+                    $scope.content = 'Some content that can be a bit longer';
+                });
+    </script>
+
+</head>
+<body ng-app="demo" ng-controller="PopoverCtrl">
+<div class="well" style="padding: 3%">
+    <div class="form-group">
+        <label for="title">Title: </label><input ng-model="title" id="title" class="form-control"/>
+    </div>
+    <div class="form-group">
+        <label for="content">Content: </label><input ng-model="content" id="content" class="form-control" />
+    </div>
+</div>
+<div class="well" style="padding: 3%">
+    <button class="btn btn-default" bs-popover="{{content}}" bs-popover-title="{{title}}" bs-popover-placement="left">Left</button>
+    <button class="btn btn-default" bs-popover="{{content}}" bs-popover-title="{{title}}" bs-popover-placement="top">Top</button>
+    <button class="btn btn-default" bs-popover="{{content}}" bs-popover-title="{{title}}" bs-popover-placement="right">Right</button>
+    <button class="btn btn-default" bs-popover="{{content}}" bs-popover-title="{{title}}" bs-popover-placement="bottom">Bottom</button>
+</div>
+
+</body>
+</html>

--- a/src/attribute_directives/exercise/popover.js
+++ b/src/attribute_directives/exercise/popover.js
@@ -1,0 +1,53 @@
+angular.module('bs.popover', [])
+  .directive('bsPopover', function () {
+
+    var popoverTpl =
+      '<div class="popover">' +
+        '<div class="arrow"></div>' +
+        '<h3 class="popover-title"></h3>' +
+        '<div class="popover-content"></div>' +
+      '</div>';
+
+    return {
+
+      compile: function (tElement, tAttrs) {
+
+        var placement = tAttrs.bsPopoverPlacement || 'top';
+        var popoverTplEl = angular.element(popoverTpl);
+        popoverTplEl.addClass(placement);
+        popoverTplEl.css('display', 'block');
+
+        return function (scope, iElement, iAttrs) {
+
+          var shown = false;
+          var popoverInstanceEl = popoverTplEl.clone();
+
+          //observe interpolated attributes and update popover's content accordingly
+          iAttrs.$observe('bsPopoverTitle', function(newTitle) {
+            popoverInstanceEl.find('.popover-title').text(newTitle);
+          });
+          iAttrs.$observe('bsPopover', function(newContent) {
+            popoverInstanceEl.find('.popover-content').text(newContent);
+          });
+
+          iElement.on('click', function () {
+
+            if (!shown) {
+
+              //attach popover to the DOM to gets its size
+              iElement.after(popoverInstanceEl);
+
+              //calculate position
+              var popoverPosition = calculatePosition(iElement, popoverInstanceEl, placement);
+              popoverInstanceEl.css(popoverPosition);
+
+            } else {
+              popoverInstanceEl.remove();
+            }
+
+            shown = !shown;
+          });
+        };
+      }
+    };
+  });

--- a/src/attribute_directives/exercise/popover.spec.js
+++ b/src/attribute_directives/exercise/popover.spec.js
@@ -1,0 +1,61 @@
+describe('popover', function () {
+
+  var $scope, $compile;
+
+  beforeEach(module('bs.popover'));
+  beforeEach(inject(function ($rootScope, _$compile_) {
+    $scope = $rootScope;
+    $compile = _$compile_;
+  }));
+
+  function compileElement(elementString, scope) {
+    var element = $compile(elementString)(scope);
+    scope.$digest();
+    return element;
+  }
+
+  it('should show and hide popover on click', function () {
+    var elm = compileElement('<div><button bs-popover="content"></button></div>', $scope);
+
+    elm.find('button').click();
+    expect(elm.find('.popover').length).toEqual(1);
+
+    elm.find('button').click();
+    expect(elm.find('.popover').length).toEqual(0);
+  });
+
+  it('should observe interpolated content and title', function () {
+    $scope.title = 't1';
+    $scope.content = 'foo';
+    var elm = compileElement('<div><button bs-popover="{{content}}" bs-popover-title="{{title}}"></button></div>', $scope);
+
+    elm.find('button').click();
+    expect(elm.find('.popover-title').text()).toEqual('t1');
+    expect(elm.find('.popover-content').text()).toEqual('foo');
+
+    $scope.title = 't2';
+    $scope.content = 'bar';
+    $scope.$digest();
+    expect(elm.find('.popover-title').text()).toEqual('t2');
+    expect(elm.find('.popover-content').text()).toEqual('bar');
+  });
+
+  describe('placement', function () {
+
+    it('should be placed on top by default', function () {
+      var elm = compileElement('<div><button bs-popover="content"></button></div>', $scope);
+
+      elm.find('button').click();
+      expect(elm.find('.popover')).toHaveClass('top');
+    });
+
+    it('should accept placement attribute', function () {
+      var elm = compileElement('<div><button bs-popover="content" bs-popover-placement="right"></button></div>', $scope);
+
+      elm.find('button').click();
+      expect(elm.find('.popover')).toHaveClass('right');
+      expect(elm.find('.popover')).not.toHaveClass('top');
+    });
+
+  });
+});


### PR DESCRIPTION
@IgorMinar new demo + exercise, this time to illustrate attribute directives that do good, old DOM manipulation. Actually those little examples illustrate many important concepts:
- factory function vs. compile function vs. linking function
- observing iterpolated attributes
- place of jQuery (low-level DOM manipulation and DOM-based testing)

so I think it might be good idea to start with exercise. We could then nicely transition to widgets and say: "hey, we can do old-fashioned DOM manipulation in directives but it is often not needed as directives with templates can be seen as mini applications " .
